### PR TITLE
change map after few successful rounds of map for model generalization

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -120,7 +120,6 @@ function draw() {
     }
 
     if (population.length !== 0 && changeMap) {
-      console.log("i ma here")
       for (let i = population.length - 1; i >= 0; i--) {
         savedParticles.push(population.splice(i, 1)[0]);
       }

--- a/sketch.js
+++ b/sketch.js
@@ -26,6 +26,15 @@ let inside = [];
 let outside = [];
 let checkpoints = [];
 
+// around 5-6 successfully completed rounds will make the fitness of 500+
+// so maxFitness is set to 500
+// thus the changeMap will flag becomes true and we will create new map
+// when any of the particle completes multiple rounds in current map
+// this will help to make the current generation to work on new map
+// and generalize to variety of maps
+const maxFitness = 500;
+let changeMap = false;
+
 function buildTrack() {
   checkpoints = [];
   inside = [];
@@ -104,6 +113,22 @@ function draw() {
       if (particle.dead || particle.finished) {
         savedParticles.push(population.splice(i, 1)[0]);
       }
+
+      if (!changeMap && particle.fitness > maxFitness) {
+        changeMap = true;
+      }
+    }
+
+    if (population.length !== 0 && changeMap) {
+      console.log("i ma here")
+      for (let i = population.length - 1; i >= 0; i--) {
+        savedParticles.push(population.splice(i, 1)[0]);
+      }
+
+      buildTrack();
+      nextGeneration();
+      generationCount++;
+      changeMap=false;
     }
 
     if (population.length == 0) {


### PR DESCRIPTION
In the existing code, new generations are not created once the particle successfully learns the current map and those particles in the map completing it triumphantly! indefinitely.
In this case, we think that the particle has learned to navigate in the maps, but it is generally overfitted to the current map only.
So, to make the particle generalize enough that it can navigate in a large variety of maps, I have added a logic to build a new map once the particle has successfully navigated the current map and made the round-trip 5-6 times.
Thus, periodically the model will explore many maps and try to adjust weights of neural network in a way that helps it navigate the variety of maps.